### PR TITLE
[FEAT] 팀원 초대 관련 기능 초안 구현

### DIFF
--- a/src/main/java/org/example/dotoli/config/error/ErrorCode.java
+++ b/src/main/java/org/example/dotoli/config/error/ErrorCode.java
@@ -15,11 +15,14 @@ public enum ErrorCode {
 
 	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "M1", "회원 정보가 존재하지 않습니다."),
 	DUPLICATE_EMAIL(HttpStatus.CONFLICT, "M2", "이미 사용 중인 이메일 주소입니다."),
+	MEMBER_ALREADY_IN_TEAM(HttpStatus.CONFLICT, "M3", "이미 팀에 소속된 회원입니다."),
 
 	DUPLICATE_TEAM_NAME(HttpStatus.CONFLICT, "TE1", "이미 사용 중인 팀 이름입니다."),
 	TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "TE2", "팀 정보가 존재하지 않습니다."),
 
-	TASK_NOT_FOUND(HttpStatus.NOT_FOUND, "T1", "할 일 정보가 존재하지 않습니다.");
+	TASK_NOT_FOUND(HttpStatus.NOT_FOUND, "T1", "할 일 정보가 존재하지 않습니다."),
+
+	DUPLICATE_INVITATION(HttpStatus.CONFLICT, "I1", "이미 대기 중인 초대가 있습니다.");
 
 	private final HttpStatus status;
 

--- a/src/main/java/org/example/dotoli/config/error/ErrorCode.java
+++ b/src/main/java/org/example/dotoli/config/error/ErrorCode.java
@@ -22,7 +22,8 @@ public enum ErrorCode {
 
 	TASK_NOT_FOUND(HttpStatus.NOT_FOUND, "T1", "할 일 정보가 존재하지 않습니다."),
 
-	DUPLICATE_INVITATION(HttpStatus.CONFLICT, "I1", "이미 대기 중인 초대가 있습니다.");
+	DUPLICATE_INVITATION(HttpStatus.CONFLICT, "I1", "이미 대기 중인 초대가 있습니다."),
+	INVITATION_NOT_FOUND(HttpStatus.NOT_FOUND, "I2", "초대 정보를 찾을 수 없습니다.");
 
 	private final HttpStatus status;
 

--- a/src/main/java/org/example/dotoli/config/error/exception/DuplicateInvitationException.java
+++ b/src/main/java/org/example/dotoli/config/error/exception/DuplicateInvitationException.java
@@ -1,0 +1,15 @@
+package org.example.dotoli.config.error.exception;
+
+import org.example.dotoli.config.error.ErrorCode;
+
+public class DuplicateInvitationException extends BusinessBaseException {
+
+	public DuplicateInvitationException() {
+		super(ErrorCode.DUPLICATE_INVITATION);
+	}
+
+	public DuplicateInvitationException(String message) {
+		super(ErrorCode.DUPLICATE_INVITATION, message);
+	}
+
+}

--- a/src/main/java/org/example/dotoli/config/error/exception/InvitationNotFoundException.java
+++ b/src/main/java/org/example/dotoli/config/error/exception/InvitationNotFoundException.java
@@ -1,0 +1,15 @@
+package org.example.dotoli.config.error.exception;
+
+import org.example.dotoli.config.error.ErrorCode;
+
+public class InvitationNotFoundException extends BusinessBaseException {
+
+	public InvitationNotFoundException() {
+		super(ErrorCode.INVITATION_NOT_FOUND);
+	}
+
+	public InvitationNotFoundException(String message) {
+		super(ErrorCode.INVITATION_NOT_FOUND, message);
+	}
+
+}

--- a/src/main/java/org/example/dotoli/config/error/exception/MemberAlreadyInTeamException.java
+++ b/src/main/java/org/example/dotoli/config/error/exception/MemberAlreadyInTeamException.java
@@ -1,0 +1,15 @@
+package org.example.dotoli.config.error.exception;
+
+import org.example.dotoli.config.error.ErrorCode;
+
+public class MemberAlreadyInTeamException extends BusinessBaseException {
+
+	public MemberAlreadyInTeamException() {
+		super(ErrorCode.MEMBER_ALREADY_IN_TEAM);
+	}
+
+	public MemberAlreadyInTeamException(String message) {
+		super(ErrorCode.MEMBER_ALREADY_IN_TEAM, message);
+	}
+
+}

--- a/src/main/java/org/example/dotoli/controller/InvitationController.java
+++ b/src/main/java/org/example/dotoli/controller/InvitationController.java
@@ -29,4 +29,26 @@ public class InvitationController {
 		return ResponseEntity.ok(invitationService.createInvitation(dto, userDetails.getMember().getId(), teamId));
 	}
 
+	@PostMapping("/{invitationId}/accept")
+	public ResponseEntity<Void> acceptInvitation(
+			@PathVariable("teamId") Long teamId,
+			@PathVariable("invitationId") Long invitationId,
+			@AuthenticationPrincipal CustomUserDetails userDetails
+	) {
+		invitationService.acceptInvitation(invitationId, userDetails.getMember().getId(), teamId);
+
+		return ResponseEntity.ok().build();
+	}
+
+	@PostMapping("/{invitationId}/reject")
+	public ResponseEntity<Void> rejectInvitation(
+			@PathVariable("teamId") Long teamId,
+			@PathVariable("invitationId") Long invitationId,
+			@AuthenticationPrincipal CustomUserDetails userDetails
+	) {
+		invitationService.rejectInvitation(invitationId, userDetails.getMember().getId(), teamId);
+		
+		return ResponseEntity.ok().build();
+	}
+
 }

--- a/src/main/java/org/example/dotoli/controller/InvitationController.java
+++ b/src/main/java/org/example/dotoli/controller/InvitationController.java
@@ -1,0 +1,32 @@
+package org.example.dotoli.controller;
+
+import org.example.dotoli.dto.invitation.InvitationRequestDto;
+import org.example.dotoli.security.userdetails.CustomUserDetails;
+import org.example.dotoli.service.InvitationService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/teams/{teamId}/invitations")
+public class InvitationController {
+
+	private final InvitationService invitationService;
+
+	@PostMapping
+	public ResponseEntity<Long> invite(
+			@PathVariable("teamId") Long teamId,
+			@RequestBody InvitationRequestDto dto,
+			@AuthenticationPrincipal CustomUserDetails userDetails
+	) {
+		return ResponseEntity.ok(invitationService.createInvitation(dto, userDetails.getMember().getId(), teamId));
+	}
+
+}

--- a/src/main/java/org/example/dotoli/dto/invitation/InvitationRequestDto.java
+++ b/src/main/java/org/example/dotoli/dto/invitation/InvitationRequestDto.java
@@ -1,0 +1,14 @@
+package org.example.dotoli.dto.invitation;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class InvitationRequestDto {
+
+	private Long inviteeId;
+
+}

--- a/src/main/java/org/example/dotoli/repository/InvitationRepository.java
+++ b/src/main/java/org/example/dotoli/repository/InvitationRepository.java
@@ -1,11 +1,14 @@
 package org.example.dotoli.repository;
 
 import org.example.dotoli.domain.Invitation;
+import org.example.dotoli.domain.InvitationStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 /**
  * 초대 정보에 대한 데이터베이스 작업을 처리하는 레포지토리 인터페이스
  */
 public interface InvitationRepository extends JpaRepository<Invitation, Long> {
+
+	boolean existsByTeamIdAndInviteeIdAndStatus(Long teamId, Long memberId, InvitationStatus status);
 
 }

--- a/src/main/java/org/example/dotoli/service/InvitationService.java
+++ b/src/main/java/org/example/dotoli/service/InvitationService.java
@@ -1,0 +1,73 @@
+package org.example.dotoli.service;
+
+import org.example.dotoli.config.error.exception.ForbiddenException;
+import org.example.dotoli.domain.Invitation;
+import org.example.dotoli.domain.InvitationStatus;
+import org.example.dotoli.domain.Member;
+import org.example.dotoli.domain.Team;
+import org.example.dotoli.dto.invitation.InvitationRequestDto;
+import org.example.dotoli.repository.InvitationRepository;
+import org.example.dotoli.repository.MemberRepository;
+import org.example.dotoli.repository.TeamMemberRepository;
+import org.example.dotoli.repository.TeamRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class InvitationService {
+
+	private final InvitationRepository invitationRepository;
+
+	private final TeamMemberRepository teamMemberRepository;
+
+	private final MemberRepository memberRepository;
+
+	private final TeamRepository teamRepository;
+
+	/**
+	 * 초대 생성
+	 */
+	@Transactional
+	public Long createInvitation(InvitationRequestDto dto, Long inviterId, Long teamId) {
+		Long inviteeId = dto.getInviteeId();
+
+		validateInvitation(inviterId, teamId, inviteeId);
+
+		Member invitee = memberRepository.getReferenceById(inviteeId);
+		Member inviter = memberRepository.getReferenceById(inviterId);
+		Team team = teamRepository.getReferenceById(teamId);
+
+		Invitation invitation = Invitation.createNew(team, inviter, invitee);
+
+		return invitationRepository.save(invitation).getId();
+	}
+
+	private void validateInvitation(Long inviterId, Long teamId, Long inviteeId) {
+		validateMemberTeamAccess(inviterId, teamId);
+		validateInviteeNotInTeam(teamId, inviteeId);
+		validateNoPendingInvitation(teamId, inviteeId);
+	}
+
+	private void validateMemberTeamAccess(Long memberId, Long teamId) {
+		if (!teamMemberRepository.existsByMemberIdAndTeamId(memberId, teamId)) {
+			throw new ForbiddenException("이 팀에 접근할 권한이 없습니다.");
+		}
+	}
+
+	private void validateInviteeNotInTeam(Long teamId, Long inviteeId) {
+		if (teamMemberRepository.existsByMemberIdAndTeamId(inviteeId, teamId)) {
+			throw new IllegalArgumentException();
+		}
+	}
+
+	private void validateNoPendingInvitation(Long teamId, Long inviteeId) {
+		if (invitationRepository.existsByTeamIdAndInviteeIdAndStatus(teamId, inviteeId, InvitationStatus.PENDING)) {
+			throw new IllegalArgumentException();
+		}
+	}
+
+}

--- a/src/main/java/org/example/dotoli/service/InvitationService.java
+++ b/src/main/java/org/example/dotoli/service/InvitationService.java
@@ -1,6 +1,8 @@
 package org.example.dotoli.service;
 
+import org.example.dotoli.config.error.exception.DuplicateInvitationException;
 import org.example.dotoli.config.error.exception.ForbiddenException;
+import org.example.dotoli.config.error.exception.MemberAlreadyInTeamException;
 import org.example.dotoli.domain.Invitation;
 import org.example.dotoli.domain.InvitationStatus;
 import org.example.dotoli.domain.Member;
@@ -60,13 +62,13 @@ public class InvitationService {
 
 	private void validateInviteeNotInTeam(Long teamId, Long inviteeId) {
 		if (teamMemberRepository.existsByMemberIdAndTeamId(inviteeId, teamId)) {
-			throw new IllegalArgumentException();
+			throw new MemberAlreadyInTeamException();
 		}
 	}
 
 	private void validateNoPendingInvitation(Long teamId, Long inviteeId) {
 		if (invitationRepository.existsByTeamIdAndInviteeIdAndStatus(teamId, inviteeId, InvitationStatus.PENDING)) {
-			throw new IllegalArgumentException();
+			throw new DuplicateInvitationException();
 		}
 	}
 

--- a/src/main/java/org/example/dotoli/service/InvitationService.java
+++ b/src/main/java/org/example/dotoli/service/InvitationService.java
@@ -2,11 +2,14 @@ package org.example.dotoli.service;
 
 import org.example.dotoli.config.error.exception.DuplicateInvitationException;
 import org.example.dotoli.config.error.exception.ForbiddenException;
+import org.example.dotoli.config.error.exception.InvitationNotFoundException;
 import org.example.dotoli.config.error.exception.MemberAlreadyInTeamException;
+import org.example.dotoli.config.error.exception.TeamNotFoundException;
 import org.example.dotoli.domain.Invitation;
 import org.example.dotoli.domain.InvitationStatus;
 import org.example.dotoli.domain.Member;
 import org.example.dotoli.domain.Team;
+import org.example.dotoli.domain.TeamMember;
 import org.example.dotoli.dto.invitation.InvitationRequestDto;
 import org.example.dotoli.repository.InvitationRepository;
 import org.example.dotoli.repository.MemberRepository;
@@ -46,6 +49,38 @@ public class InvitationService {
 		Invitation invitation = Invitation.createNew(team, inviter, invitee);
 
 		return invitationRepository.save(invitation).getId();
+	}
+
+	/**
+	 * 초대 수락
+	 */
+	@Transactional
+	public void acceptInvitation(Long invitationId, Long inviteeId, Long teamId) {
+		Invitation invitation = invitationRepository.findById(invitationId)
+				.orElseThrow(InvitationNotFoundException::new);
+		Team team = teamRepository.findById(teamId)
+				.orElseThrow(TeamNotFoundException::new);
+		Member invitee = memberRepository.getReferenceById(inviteeId);
+
+		// TODO: 검증 로직 추가 필요
+
+		invitation.accept();
+		TeamMember teamMember = TeamMember.createNew(invitee, team);
+
+		teamMemberRepository.save(teamMember);
+	}
+
+	/**
+	 * 초대 거절
+	 */
+	@Transactional
+	public void rejectInvitation(Long invitationId, Long inviteeId, Long teamId) {
+		Invitation invitation = invitationRepository.findById(invitationId)
+				.orElseThrow(InvitationNotFoundException::new);
+
+		// TODO: 검증 로직 추가 필요
+
+		invitation.reject();
 	}
 
 	private void validateInvitation(Long inviterId, Long teamId, Long inviteeId) {


### PR DESCRIPTION
## 관련 이슈
- Closes #24 

## 변경 사항
1. 팀 초대 생성 기능 구현
   - `InvitationRequestDto` 클래스 추가
   - `InvitationService` 클래스에 초대 생성 로직 구현 및 검증 메서드 추가
   - `InvitationRepository`에 초대 존재 유무 메서드 추가

2. 팀 초대 생성 기능의 예외 처리 개선
   - `DuplicateInvitationException` 및 `MemberAlreadyInTeamException` 클래스 추가
   - `ErrorCode`에 `DUPLICATE_INVITATION` 및 `MEMBER_ALREADY_IN_TEAM` 에러 코드 추가
   - `InvitationService` 클래스의 `validateInviteeNotInTeam` 및 `validateNoPendingInvitation` 메서드에 커스텀 예외 적용

3. 초대 수락 및 거절 기능 구현
   - `acceptInvitation` 메서드 추가
   - `rejectInvitation` 메서드 추가
   - `InvitationNotFoundException` 예외 클래스 추가
   - `ErrorCode`에 `INVITATION_NOT_FOUND` 에러 코드 추가

4. 팀 초대 API 엔드포인트 구현
   - `InvitationController` 클래스 생성
   - `POST /api/teams/{teamId}/invitations` 엔드포인트 추가
   - 팀 초대 생성 기능 구현

5. 팀 초대 수락 및 거절 API 엔드포인트 추가
   - `POST /api/teams/{teamId}/invitations/{invitationId}/accept` 엔드포인트 구현
   - `POST /api/teams/{teamId}/invitations/{invitationId}/reject` 엔드포인트 구현
   - 인증된 사용자 정보를 활용한 초대 수락/거절 처리

## 스크린샷

| 기능명 | 스크린샷 |
|--------|----------|
| 팀원 초대 | ![팀원 초대](https://github.com/user-attachments/assets/75db7f28-e884-41d2-9465-b4dccf572f99) |
| 초대 수락 | ![초대 수락](https://github.com/user-attachments/assets/34c233e7-84aa-4a2a-8ed2-d13629379a30) |
| 할일 추가 | ![할일 추가](https://github.com/user-attachments/assets/bd24d313-62eb-4304-8184-5a3089c5c0e5) |
| 할일 조회 | ![할일 조회](https://github.com/user-attachments/assets/bc758abb-ded5-46f0-8a96-41bb9db8272f) |

## 체크리스트
- [x] 코드 컨벤션을 준수하였습니까?
- [x] 모든 테스트를 통과하였습니까?
- [x] 관련 문서를 업데이트하였습니까?

## 공유사항
- 검증 로직의 복잡성이 생각보다 높아 초대 수락 및 거절 기능에 대한 검증 로직은 포함하지 않았습니다. 추후 새로운 이슈로 작업을 진행할 예정입니다.
- 초대 목록 조회 등 아직 구현되어 있지 않은 엔드포인트가 존재합니다. 추후 프론트엔드와 병행 개발을 진행하며 점진적으로 추가할 예정입니다.

## 추후 업무
- [ ] 초대 수락 및 거절 기능에 대한 추가 검증 로직 구현
- [ ] 팀 초대 관련 단위 테스트 작성
- [ ] 프론트엔드 병행 개발 간 필요한 엔드포인트 및 비즈니스 로직 구현