### PR TITLE
[REFACTOR] Task 엔티티 생성 메서드 통합 리팩토링

### DIFF
--- a/src/main/java/org/example/dotoli/controller/PersonalTaskController.java
+++ b/src/main/java/org/example/dotoli/controller/PersonalTaskController.java
@@ -30,7 +30,7 @@ import lombok.RequiredArgsConstructor;
  */
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/tasks")
+@RequestMapping("/api/tasks") // TODO: URI 고민 필요, /api/personal/tasks
 public class PersonalTaskController {
 
 	private final PersonalTaskService personalTaskService;
@@ -56,7 +56,8 @@ public class PersonalTaskController {
 			@RequestParam(defaultValue = "5") int size
 	) {
 		Pageable pageable = PageRequest.of(page, size);
-		Page<TaskResponseDto> tasks = personalTaskService.getAllTasksByMemberId(userDetails.getMember().getId(), pageable);
+		Page<TaskResponseDto> tasks = personalTaskService.getAllTasksByMemberId(userDetails.getMember().getId(),
+				pageable);
 		return ResponseEntity.ok(tasks);
 	}
 

--- a/src/main/java/org/example/dotoli/controller/PersonalTaskController.java
+++ b/src/main/java/org/example/dotoli/controller/PersonalTaskController.java
@@ -43,7 +43,7 @@ public class PersonalTaskController {
 			@RequestBody @Valid TaskRequestDto dto,
 			@AuthenticationPrincipal CustomUserDetails userDetails
 	) {
-		return ResponseEntity.ok(personalTaskService.createDetailedTask(dto, userDetails.getMember().getId()));
+		return ResponseEntity.ok(personalTaskService.createTask(dto, userDetails.getMember().getId()));
 	}
 
 	/**

--- a/src/main/java/org/example/dotoli/controller/PersonalTaskController.java
+++ b/src/main/java/org/example/dotoli/controller/PersonalTaskController.java
@@ -36,10 +36,10 @@ public class PersonalTaskController {
 	private final PersonalTaskService personalTaskService;
 
 	/**
-	 * 상세한 할 일 추가
+	 * 할 일 추가
 	 */
-	@PostMapping("/detailed")
-	public ResponseEntity<Long> addDetailedTask(
+	@PostMapping
+	public ResponseEntity<Long> addTask(
 			@RequestBody @Valid TaskRequestDto dto,
 			@AuthenticationPrincipal CustomUserDetails userDetails
 	) {

--- a/src/main/java/org/example/dotoli/controller/PersonalTaskController.java
+++ b/src/main/java/org/example/dotoli/controller/PersonalTaskController.java
@@ -36,17 +36,6 @@ public class PersonalTaskController {
 	private final PersonalTaskService personalTaskService;
 
 	/**
-	 * 간단한 할 일 추가
-	 */
-	@PostMapping("/simple")
-	public ResponseEntity<Long> addSimpleTask(
-			@RequestBody @Valid TaskRequestDto dto,
-			@AuthenticationPrincipal CustomUserDetails userDetails
-	) {
-		return ResponseEntity.ok(personalTaskService.createSimpleTask(dto, userDetails.getMember().getId()));
-	}
-
-	/**
 	 * 상세한 할 일 추가
 	 */
 	@PostMapping("/detailed")

--- a/src/main/java/org/example/dotoli/controller/TeamTaskController.java
+++ b/src/main/java/org/example/dotoli/controller/TeamTaskController.java
@@ -34,17 +34,6 @@ public class TeamTaskController {
 	private final TeamTaskService teamTaskService;
 
 	/**
-	 * 간단한 팀 할 일 추가
-	 */
-	@PostMapping("/tasks/simple")
-	public ResponseEntity<Long> addSimpleTask(
-			@RequestBody @Validated(TeamTaskValidation.class) TaskRequestDto dto,
-			@AuthenticationPrincipal CustomUserDetails userDetails
-	) {
-		return ResponseEntity.ok(teamTaskService.createSimpleTask(dto, userDetails.getMember().getId()));
-	}
-
-	/**
 	 * 상세한 팀 할 일 추가
 	 */
 	@PostMapping("/tasks/detailed")

--- a/src/main/java/org/example/dotoli/controller/TeamTaskController.java
+++ b/src/main/java/org/example/dotoli/controller/TeamTaskController.java
@@ -41,7 +41,7 @@ public class TeamTaskController {
 			@RequestBody @Validated(TeamTaskValidation.class) TaskRequestDto dto,
 			@AuthenticationPrincipal CustomUserDetails userDetails
 	) {
-		return ResponseEntity.ok(teamTaskService.createDetailedTask(dto, userDetails.getMember().getId()));
+		return ResponseEntity.ok(teamTaskService.createTask(dto, userDetails.getMember().getId()));
 	}
 
 	/**

--- a/src/main/java/org/example/dotoli/controller/TeamTaskController.java
+++ b/src/main/java/org/example/dotoli/controller/TeamTaskController.java
@@ -36,7 +36,7 @@ public class TeamTaskController {
 	/**
 	 * 할 일 추가
 	 */
-	@PostMapping
+	@PostMapping("/tasks")
 	public ResponseEntity<Long> addTask(
 			@RequestBody @Validated(TeamTaskValidation.class) TaskRequestDto dto,
 			@AuthenticationPrincipal CustomUserDetails userDetails

--- a/src/main/java/org/example/dotoli/controller/TeamTaskController.java
+++ b/src/main/java/org/example/dotoli/controller/TeamTaskController.java
@@ -34,10 +34,10 @@ public class TeamTaskController {
 	private final TeamTaskService teamTaskService;
 
 	/**
-	 * 상세한 팀 할 일 추가
+	 * 할 일 추가
 	 */
-	@PostMapping("/tasks/detailed")
-	public ResponseEntity<Long> addDetailedTask(
+	@PostMapping
+	public ResponseEntity<Long> addTask(
 			@RequestBody @Validated(TeamTaskValidation.class) TaskRequestDto dto,
 			@AuthenticationPrincipal CustomUserDetails userDetails
 	) {

--- a/src/main/java/org/example/dotoli/domain/Task.java
+++ b/src/main/java/org/example/dotoli/domain/Task.java
@@ -45,7 +45,6 @@ public class Task {
 	@ManyToOne(fetch = FetchType.LAZY)
 	private Team team;
 
-	// 공통 할 일 생성 메서드
 	private Task(String content, Member member, LocalDate deadline, boolean flag, Team team) {
 		this.content = content;
 		this.member = member;

--- a/src/main/java/org/example/dotoli/domain/Task.java
+++ b/src/main/java/org/example/dotoli/domain/Task.java
@@ -55,10 +55,6 @@ public class Task {
 		this.done = false;
 	}
 
-	// 간단한 할 일 생성 메소드
-	public static Task createSimplePersonalTask(String content, Member member) {
-		return new Task(content, member, null, false, null);
-	}
 
 	/**
 	 * 개인 할 일 생성 메서드

--- a/src/main/java/org/example/dotoli/domain/Task.java
+++ b/src/main/java/org/example/dotoli/domain/Task.java
@@ -60,8 +60,10 @@ public class Task {
 		return new Task(content, member, null, false, null);
 	}
 
-	// 상세 할 일 생성 메소드
-	public static Task createDetailedPersonalTask(String content, Member member, LocalDate deadline, boolean flag) {
+	/**
+	 * 개인 할 일 생성 메서드
+	 */
+	public static Task createPersonalTask(String content, Member member, LocalDate deadline, boolean flag) {
 		return new Task(content, member, deadline, flag, null);
 	}
 
@@ -69,8 +71,10 @@ public class Task {
 		return new Task(content, member, null, false, team);
 	}
 
-	public static Task createDetailedTeamTask(String content, Member member, LocalDate deadline, boolean flag,
-			Team team) {
+	/**
+	 * 팀 할 일 생성 메서드
+	 */
+	public static Task createTeamTask(String content, Member member, LocalDate deadline, boolean flag, Team team) {
 		return new Task(content, member, deadline, flag, team);
 	}
 

--- a/src/main/java/org/example/dotoli/domain/Task.java
+++ b/src/main/java/org/example/dotoli/domain/Task.java
@@ -55,16 +55,11 @@ public class Task {
 		this.done = false;
 	}
 
-
 	/**
 	 * 개인 할 일 생성 메서드
 	 */
 	public static Task createPersonalTask(String content, Member member, LocalDate deadline, boolean flag) {
 		return new Task(content, member, deadline, flag, null);
-	}
-
-	public static Task createSimpleTeamTask(String content, Member member, Team team) {
-		return new Task(content, member, null, false, team);
 	}
 
 	/**

--- a/src/main/java/org/example/dotoli/service/PersonalTaskService.java
+++ b/src/main/java/org/example/dotoli/service/PersonalTaskService.java
@@ -34,17 +34,6 @@ public class PersonalTaskService implements TaskService {
 	private final TaskRepositoryCustom taskRepositoryCustom;
 
 	/**
-	 * 간단한 할 일 추가
-	 */
-	@Override
-	@Transactional
-	public Long createSimpleTask(TaskRequestDto dto, Long currentMemberId) {
-		Member member = memberRepository.getReferenceById(currentMemberId);
-		Task task = Task.createSimplePersonalTask(dto.getContent(), member);
-		return taskRepository.save(task).getId();
-	}
-
-	/**
 	 * 상세한 할 일 추가
 	 */
 	@Override

--- a/src/main/java/org/example/dotoli/service/PersonalTaskService.java
+++ b/src/main/java/org/example/dotoli/service/PersonalTaskService.java
@@ -38,8 +38,8 @@ public class PersonalTaskService implements TaskService {
 	 */
 	@Override
 	@Transactional
-	public Long createTask(TaskRequestDto dto, Long currentMemberId) {
-		Member member = memberRepository.getReferenceById(currentMemberId);
+	public Long createTask(TaskRequestDto dto, Long memberId) {
+		Member member = memberRepository.getReferenceById(memberId);
 		Task task = Task.createPersonalTask(dto.getContent(), member, dto.getDeadline(), dto.isFlag());
 		return taskRepository.save(task).getId();
 	}
@@ -82,8 +82,8 @@ public class PersonalTaskService implements TaskService {
 	 */
 	@Override
 	@Transactional
-	public void updateTask(Long taskId, TaskRequestDto dto, Long currentMemberId) {
-		Task task = findTaskAndValidateOwnership(taskId, currentMemberId);
+	public void updateTask(Long taskId, TaskRequestDto dto, Long memberId) {
+		Task task = findTaskAndValidateOwnership(taskId, memberId);
 
 		task.updateContent(dto.getContent());
 		task.updateDeadline(dto.getDeadline());
@@ -95,8 +95,8 @@ public class PersonalTaskService implements TaskService {
 	 */
 	@Override
 	@Transactional
-	public void deleteTask(Long targetId, Long currentMemberId) {
-		Task task = findTaskAndValidateOwnership(targetId, currentMemberId);
+	public void deleteTask(Long targetId, Long memberId) {
+		Task task = findTaskAndValidateOwnership(targetId, memberId);
 
 		taskRepository.delete(task);
 	}
@@ -106,8 +106,8 @@ public class PersonalTaskService implements TaskService {
 	 */
 	@Override
 	@Transactional
-	public void toggleDone(Long targetId, ToggleRequestDto dto, Long currentMemberId) {
-		Task task = findTaskAndValidateOwnership(targetId, currentMemberId);
+	public void toggleDone(Long targetId, ToggleRequestDto dto, Long memberId) {
+		Task task = findTaskAndValidateOwnership(targetId, memberId);
 
 		task.updateDone(dto.isDone());
 	}
@@ -115,11 +115,11 @@ public class PersonalTaskService implements TaskService {
 	/**
 	 * 특정 할 일 조회 및 소유권 확인
 	 */
-	private Task findTaskAndValidateOwnership(Long taskId, Long currentMemberId) {
+	private Task findTaskAndValidateOwnership(Long taskId, Long memberId) {
 		Task task = taskRepository.findById(taskId)
 				.orElseThrow(TaskNotFoundException::new);
 
-		validateTaskOwnership(task.getMember().getId(), currentMemberId);
+		validateTaskOwnership(task.getMember().getId(), memberId);
 
 		return task;
 	}

--- a/src/main/java/org/example/dotoli/service/PersonalTaskService.java
+++ b/src/main/java/org/example/dotoli/service/PersonalTaskService.java
@@ -51,7 +51,7 @@ public class PersonalTaskService implements TaskService {
 	@Transactional
 	public Long createDetailedTask(TaskRequestDto dto, Long currentMemberId) {
 		Member member = memberRepository.getReferenceById(currentMemberId);
-		Task task = Task.createDetailedPersonalTask(dto.getContent(), member, dto.getDeadline(), dto.isFlag());
+		Task task = Task.createPersonalTask(dto.getContent(), member, dto.getDeadline(), dto.isFlag());
 		return taskRepository.save(task).getId();
 	}
 

--- a/src/main/java/org/example/dotoli/service/PersonalTaskService.java
+++ b/src/main/java/org/example/dotoli/service/PersonalTaskService.java
@@ -34,7 +34,7 @@ public class PersonalTaskService implements TaskService {
 	private final TaskRepositoryCustom taskRepositoryCustom;
 
 	/**
-	 * 상세한 할 일 추가
+	 * 할 일 추가
 	 */
 	@Override
 	@Transactional

--- a/src/main/java/org/example/dotoli/service/PersonalTaskService.java
+++ b/src/main/java/org/example/dotoli/service/PersonalTaskService.java
@@ -38,7 +38,7 @@ public class PersonalTaskService implements TaskService {
 	 */
 	@Override
 	@Transactional
-	public Long createDetailedTask(TaskRequestDto dto, Long currentMemberId) {
+	public Long createTask(TaskRequestDto dto, Long currentMemberId) {
 		Member member = memberRepository.getReferenceById(currentMemberId);
 		Task task = Task.createPersonalTask(dto.getContent(), member, dto.getDeadline(), dto.isFlag());
 		return taskRepository.save(task).getId();

--- a/src/main/java/org/example/dotoli/service/TaskService.java
+++ b/src/main/java/org/example/dotoli/service/TaskService.java
@@ -6,8 +6,6 @@ import org.example.dotoli.dto.task.ToggleRequestDto;
 
 public interface TaskService {
 
-	Long createSimpleTask(TaskRequestDto dto, Long memberId);
-
 	Long createDetailedTask(TaskRequestDto dto, Long memberId);
 
 	TaskResponseDto getTaskById(Long taskId, Long memberId);

--- a/src/main/java/org/example/dotoli/service/TaskService.java
+++ b/src/main/java/org/example/dotoli/service/TaskService.java
@@ -6,7 +6,7 @@ import org.example.dotoli.dto.task.ToggleRequestDto;
 
 public interface TaskService {
 
-	Long createDetailedTask(TaskRequestDto dto, Long memberId);
+	Long createTask(TaskRequestDto dto, Long memberId);
 
 	TaskResponseDto getTaskById(Long taskId, Long memberId);
 

--- a/src/main/java/org/example/dotoli/service/TeamTaskService.java
+++ b/src/main/java/org/example/dotoli/service/TeamTaskService.java
@@ -66,7 +66,7 @@ public class TeamTaskService implements TaskService {
 		Member member = memberRepository.getReferenceById(memberId);
 		Team team = teamRepository.getReferenceById(teamId);
 
-		Task task = Task.createDetailedTeamTask(dto.getContent(), member, dto.getDeadline(), dto.isFlag(), team);
+		Task task = Task.createTeamTask(dto.getContent(), member, dto.getDeadline(), dto.isFlag(), team);
 
 		return taskRepository.save(task).getId();
 	}

--- a/src/main/java/org/example/dotoli/service/TeamTaskService.java
+++ b/src/main/java/org/example/dotoli/service/TeamTaskService.java
@@ -36,24 +36,6 @@ public class TeamTaskService implements TaskService {
 	private final TeamMemberRepository teamMemberRepository;
 
 	/**
-	 * 간단한 할 일 추가
-	 */
-	@Override
-	@Transactional
-	public Long createSimpleTask(TaskRequestDto dto, Long memberId) {
-		Long teamId = dto.getTeamId();
-
-		validateMemberTeamAccess(memberId, teamId);
-
-		Member member = memberRepository.getReferenceById(memberId);
-		Team team = teamRepository.getReferenceById(teamId);
-
-		Task task = Task.createSimpleTeamTask(dto.getContent(), member, team);
-
-		return taskRepository.save(task).getId();
-	}
-
-	/**
 	 * 상세한 할 일 추가
 	 */
 	@Override

--- a/src/main/java/org/example/dotoli/service/TeamTaskService.java
+++ b/src/main/java/org/example/dotoli/service/TeamTaskService.java
@@ -36,7 +36,7 @@ public class TeamTaskService implements TaskService {
 	private final TeamMemberRepository teamMemberRepository;
 
 	/**
-	 * 상세한 할 일 추가
+	 * 할 일 추가
 	 */
 	@Override
 	@Transactional

--- a/src/main/java/org/example/dotoli/service/TeamTaskService.java
+++ b/src/main/java/org/example/dotoli/service/TeamTaskService.java
@@ -40,7 +40,7 @@ public class TeamTaskService implements TaskService {
 	 */
 	@Override
 	@Transactional
-	public Long createDetailedTask(TaskRequestDto dto, Long memberId) {
+	public Long createTask(TaskRequestDto dto, Long memberId) {
 		Long teamId = dto.getTeamId();
 
 		validateMemberTeamAccess(memberId, teamId);


### PR DESCRIPTION
## 관련 이슈
- Closes #26 

## 변경 사항

1. `Task` 엔티티 리팩토링
   - `createDetailedPersonalTask`를 `createPersonalTask`로 변경
   - `createDetailedTeamTask`를 `createTeamTask`로 변경
   - `createTeamTask` 메서드에 주석 추가
   - `createSimplePersonalTask` 메서드 제거
   - `createTeamPersonalTask` 메서드 제거
   - 불필요한 주석 제거

2. `TaskService` 인터페이스 리팩토링
   - `createDetailedTask`를 `createTask`로 변경

3. 컨트롤러 레이어 리팩토링
   - `PersonalTaskController`와 `TeamTaskController`의 엔드포인트 수정
     - `POST /api/tasks/detailed` -> `POST /api/tasks`
     - `POST /api/teams/detailed` -> `POST /api/teams/tasks`
   - 메서드 설명 주석 수정

4. 서비스 레이어 리팩토링
   - `TaskService.createSimpleTask` 제거
   - 관련 서비스 레이어 클래스들의 메서드 제거
   - `PersonalTaskService`와 `TeamTaskService` 주석 수정
   - `PersonalTaskService` 일부 메서드 매개변수 네이밍 수정 (`currentMemberId` -> `memberId`)

## 스크린샷
| 기능명 | 스크린샷 |
|---|---|
| 개인 간단 할 일 추가 | ![image](https://github.com/user-attachments/assets/54722f52-4acb-4e0d-bb81-a4829473f17f) |
| 개인 상세 할 일 추가 | ![image](https://github.com/user-attachments/assets/515699b0-5d9b-4e5c-b8a4-03c7f792fb98) |
| 팀 간단 할 일 추가 | ![image](https://github.com/user-attachments/assets/f9007e8c-4e00-45e7-8746-8126d1cd7e1e) |
| 팀 상세 할 일 추가 | ![image](https://github.com/user-attachments/assets/bf090d82-0db0-41af-b68a-fceb709f8d2d) |
## 체크리스트
- [x] 코드 컨벤션을 준수하였습니까?
- [x] 모든 테스트를 통과하였습니까?
- [x] 관련 문서를 업데이트하였습니까?

## 공유사항
- 이번 PR은 `Task` 관련 엔티티, 서비스, 컨트롤러에 대한 전반적인 리팩토링을 포함하고 있습니다.
- 특히 메서드 네이밍과 엔드포인트 경로의 일관성을 개선하였습니다.
- 불필요한 메서드와 주석을 제거하여 코드의 간결성을 높였습니다.

## 추후 업무
- [ ] 리팩토링으로 인한 영향을 받는 다른 부분 검토 및 필요시 추가 수정
- [ ] TaskService 제거 고려 및 팀 할 일 엔드포인트 및 비즈니스 로직 리팩토링