### PR TITLE
[FEAT] 마이페이지 팀 초대 수신 목록 기능 구현

### DIFF
--- a/src/main/java/org/example/dotoli/dto/invitation/PendingInvitationDto.java
+++ b/src/main/java/org/example/dotoli/dto/invitation/PendingInvitationDto.java
@@ -3,11 +3,16 @@ package org.example.dotoli.dto.invitation;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+/**
+ * 초대 수신 목록 정보를 담는 DTO 클래스
+ */
 @Data
 @NoArgsConstructor
 public class PendingInvitationDto {
 
 	private Long id;
+
+	private Long teamId;
 
 	private String teamName;
 
@@ -15,8 +20,9 @@ public class PendingInvitationDto {
 
 	private String inviterEmail;
 
-	public PendingInvitationDto(Long id, String teamName, String inviterNickname, String inviterEmail) {
+	public PendingInvitationDto(Long id, Long teamId, String teamName, String inviterNickname, String inviterEmail) {
 		this.id = id;
+		this.teamId = teamId;
 		this.teamName = teamName;
 		this.inviterNickname = inviterNickname;
 		this.inviterEmail = inviterEmail;

--- a/src/main/java/org/example/dotoli/dto/invitation/PendingInvitationDto.java
+++ b/src/main/java/org/example/dotoli/dto/invitation/PendingInvitationDto.java
@@ -1,0 +1,25 @@
+package org.example.dotoli.dto.invitation;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class PendingInvitationDto {
+
+	private Long id;
+
+	private String teamName;
+
+	private String inviterNickname;
+
+	private String inviterEmail;
+
+	public PendingInvitationDto(Long id, String teamName, String inviterNickname, String inviterEmail) {
+		this.id = id;
+		this.teamName = teamName;
+		this.inviterNickname = inviterNickname;
+		this.inviterEmail = inviterEmail;
+	}
+
+}

--- a/src/main/java/org/example/dotoli/dto/member/MyPageResponseDto.java
+++ b/src/main/java/org/example/dotoli/dto/member/MyPageResponseDto.java
@@ -31,8 +31,7 @@ public class MyPageResponseDto {
 		this.totalTaskCount = totalTaskCount;
 		this.completedTaskCount = completedTaskCount;
 		this.achievementRate = achievementRate;
-		this.invitations = invitations != null ? invitations : new ArrayList<>(); // null 체크
-
+		this.invitations = invitations;
 	}
 
 	public void setMemberInfo(String email, String nickname) {

--- a/src/main/java/org/example/dotoli/dto/member/MyPageResponseDto.java
+++ b/src/main/java/org/example/dotoli/dto/member/MyPageResponseDto.java
@@ -1,5 +1,10 @@
 package org.example.dotoli.dto.member;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.example.dotoli.dto.invitation.PendingInvitationDto;
+
 import lombok.Data;
 
 /**
@@ -18,12 +23,16 @@ public class MyPageResponseDto {
 
 	private Long achievementRate;
 
+	private List<PendingInvitationDto> invitations;
+
 	public MyPageResponseDto(
-			Long totalTaskCount, Long completedTaskCount, Long achievementRate
+			Long totalTaskCount, Long completedTaskCount, Long achievementRate, List<PendingInvitationDto> invitations
 	) {
 		this.totalTaskCount = totalTaskCount;
 		this.completedTaskCount = completedTaskCount;
 		this.achievementRate = achievementRate;
+		this.invitations = invitations != null ? invitations : new ArrayList<>(); // null 체크
+
 	}
 
 	public void setMemberInfo(String email, String nickname) {

--- a/src/main/java/org/example/dotoli/repository/InvitationRepository.java
+++ b/src/main/java/org/example/dotoli/repository/InvitationRepository.java
@@ -1,13 +1,29 @@
 package org.example.dotoli.repository;
 
+import java.util.List;
+
 import org.example.dotoli.domain.Invitation;
 import org.example.dotoli.domain.InvitationStatus;
+import org.example.dotoli.dto.invitation.PendingInvitationDto;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 /**
  * 초대 정보에 대한 데이터베이스 작업을 처리하는 레포지토리 인터페이스
  */
 public interface InvitationRepository extends JpaRepository<Invitation, Long> {
+
+	/**
+	 * 초대 수신 목록
+	 */
+	@Query("SELECT new org.example.dotoli.dto.invitation.PendingInvitationDto(i.id, t.teamName, m.nickname, m.email) " +
+			"FROM Invitation i " +
+			"JOIN Team t ON i.team.id = t.id " +
+			"JOIN Member m ON i.inviter.id = m.id " +
+			"WHERE i.invitee.id = :inviteeId " +
+			"AND i.status = 'PENDING'")
+	List<PendingInvitationDto> findPendingInvitationsByInviteeId(@Param("inviteeId") Long inviteeId);
 
 	boolean existsByTeamIdAndInviteeIdAndStatus(Long teamId, Long memberId, InvitationStatus status);
 

--- a/src/main/java/org/example/dotoli/repository/InvitationRepository.java
+++ b/src/main/java/org/example/dotoli/repository/InvitationRepository.java
@@ -17,7 +17,8 @@ public interface InvitationRepository extends JpaRepository<Invitation, Long> {
 	/**
 	 * 초대 수신 목록
 	 */
-	@Query("SELECT new org.example.dotoli.dto.invitation.PendingInvitationDto(i.id, t.teamName, m.nickname, m.email) " +
+	@Query("SELECT new org.example.dotoli.dto.invitation.PendingInvitationDto " +
+			"(i.id, t.id, t.teamName, m.nickname, m.email) " +
 			"FROM Invitation i " +
 			"JOIN Team t ON i.team.id = t.id " +
 			"JOIN Member m ON i.inviter.id = m.id " +

--- a/src/main/java/org/example/dotoli/service/MyPageService.java
+++ b/src/main/java/org/example/dotoli/service/MyPageService.java
@@ -1,6 +1,10 @@
 package org.example.dotoli.service;
 
+import java.util.List;
+
+import org.example.dotoli.dto.invitation.PendingInvitationDto;
 import org.example.dotoli.dto.member.MyPageResponseDto;
+import org.example.dotoli.repository.InvitationRepository;
 import org.example.dotoli.repository.TaskRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,6 +21,8 @@ public class MyPageService {
 
 	private final TaskRepository taskRepository;
 
+	private final InvitationRepository invitationRepository;
+
 	/**
 	 * 사용자 ID에 해당하는 마이페이지 정보를 MyPageResponseDto에 담아 반환
 	 */
@@ -24,8 +30,10 @@ public class MyPageService {
 		Long totalTasksCount = taskRepository.countAllTasksByMemberId(memberId);
 		Long completedTasksCount = taskRepository.countCompletedTasksByMemberId(memberId);
 		Long completionRate = calculateCompletionRate(totalTasksCount, completedTasksCount);
+		List<PendingInvitationDto> pendingInvitationDtos
+				= invitationRepository.findPendingInvitationsByInviteeId(memberId);
 
-		return new MyPageResponseDto(totalTasksCount, completedTasksCount, completionRate);
+		return new MyPageResponseDto(totalTasksCount, completedTasksCount, completionRate, pendingInvitationDtos);
 	}
 
 	/**


### PR DESCRIPTION
## 관련 이슈
<!-- 관련된 이슈 번호를 적어주세요. -->
<!-- ex) Closes #이슈번호 -->
- Closes #36 

## 변경 사항
<!-- 이 PR에서 변경된 주요 내용을 설명해주세요.
     변경사항이 여러 개일 경우, 주요 내용과 하위 항목을 구분하여 작성해주세요. -->
<!-- ex) 1. 000 엔티티 구현 -->
<!--        - 000 메서드 구현 -->
1. 초대 발신자와 팀의 정보를 담은 `PendingInvitationDto` 생성
   - `invitationId`: 초대 아이디
   - `teamId:` 팀 아이디
   - `teamName`: 팀 이름
   - `nickName`: 초대 발신자 닉네임
   - `email`: 초대 발신자 이메일
   - `Invitation` status = 'PENDING'
3. `InvitationRepository`에 `PendingInvitationDto`의 정보를 조회하는 쿼리 추가
4. `MyPageResponseDto`에 초대 수신 목록 필드 추가
5. `MyPageService`에 초대 수신 목록 로직 추가

## 스크린샷
<!-- (선택) 주요 변경사항(기능 구현 화면, 테스트 결과 등)에 대한 이미지를 삽입해주세요. -->
<!-- 변경사항에 따라 아래 표 템플릿을 활용해주세요 -->
|기능명|스크린샷|
|---|---|
|팀 초대 수신 목록|![수락_거절테이블](https://github.com/user-attachments/assets/3f82c6e8-78a5-4d38-8d48-0c17138cd682)![수락_거절테이블2](https://github.com/user-attachments/assets/30392924-cbc9-47b7-957a-a57f454e31f4)|

## 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 사항들입니다. -->
- [x] 코드 컨벤션을 준수하였습니까?
- [x] 모든 테스트를 통과하였습니까?
- [x] 관련 문서를 업데이트하였습니까?
